### PR TITLE
Null objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,9 +94,9 @@ function recurse(parent, theirs, mine, path, options) {
  */
 function processKeyValuePair(key, value, parent, theirs, mine, path, options) {
   options = options || {};
-  var parentValue = typeof parent !== 'undefined' ? (parent !== null ? parent[key] : parent ) : undefined;
-  var theirsValue = typeof theirs !== 'undefined' ? (theirs !== null ? theirs[key] : theirs ) : undefined;
-  var mineValue = typeof mine !== 'undefined' ? (mine !== null ? mine[key] : mine ) : undefined;
+  var parentValue = (typeof parent !== 'undefined' && parent !== null && typeof parent[key] !== 'undefined') ? parent[key] : undefined;
+  var theirsValue = (typeof theirs !== 'undefined' && theirs !== null && typeof theirs[key] !== 'undefined') ? theirs[key] : undefined;
+  var mineValue = (typeof mine !== 'undefined' && mine !== null && typeof mine[key] !== 'undefined') ? mine[key] : undefined;
   var results = [];
 
   // Only process keys that have no options, or have not been flagged as ignored

--- a/index.js
+++ b/index.js
@@ -94,9 +94,9 @@ function recurse(parent, theirs, mine, path, options) {
  */
 function processKeyValuePair(key, value, parent, theirs, mine, path, options) {
   options = options || {};
-  var parentValue = typeof parent !== 'undefined' ? parent[key] : undefined;
-  var theirsValue = typeof theirs !== 'undefined' ? theirs[key] : undefined;
-  var mineValue = typeof mine !== 'undefined' ? mine[key] : undefined;
+  var parentValue = typeof parent !== 'undefined' ? (parent !== null ? parent[key] : parent ) : undefined;
+  var theirsValue = typeof theirs !== 'undefined' ? (theirs !== null ? theirs[key] : theirs ) : undefined;
+  var mineValue = typeof mine !== 'undefined' ? (mine !== null ? mine[key] : mine ) : undefined;
   var results = [];
 
   // Only process keys that have no options, or have not been flagged as ignored

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3-way-diff",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "3-way diffing of JavaScript objects",
   "main": "index.js",
   "repository": "WennerMedia/3-way-diff",

--- a/test/literals.js
+++ b/test/literals.js
@@ -480,10 +480,8 @@ describe('Literals Diff', function() {
     };
     var expected = [
       {
-        kind: 'E',
+        kind: 'N',
         path: [ 'key', 'childKey'],
-        parent: parent.key,
-        theirs: parent.key,
         mine: mine.key.childKey
       }
     ];

--- a/test/literals.js
+++ b/test/literals.js
@@ -465,6 +465,76 @@ describe('Literals Diff', function() {
     ];
     assert.deepEqual(diff(parent, theirs, mine, {keyIgnored: {ignoreKey: true}}), expected);
   });
+
+  it('mine add nested childKey where the parent key is null', function() {
+    var parent = {
+      key: null
+    };
+    var theirs = {
+      key: null
+    };
+    var mine = {
+      key: {
+        childKey: 'value',
+      }
+    };
+    var expected = [
+      {
+        kind: 'E',
+        path: [ 'key', 'childKey'],
+        parent: parent.key,
+        theirs: parent.key,
+        mine: mine.key.childKey
+      }
+    ];
+    assert.deepEqual(diff(parent, theirs, mine), expected);
+  });
+
+  it('mine/theirs add nested childKey where the parent key is null', function() {
+    var parent = {
+      key: null
+    };
+    var theirs = {
+      key: {
+        childKey: 'value'
+      }
+    };
+    var mine = {
+      key: {
+        childKey: 'value',
+      }
+    };
+    var expected = [
+      // No differences
+    ];
+    assert.deepEqual(diff(parent, theirs, mine), expected);
+  });
+
+  it('mine/theirs add nested childKey with different values where the parent key is null', function() {
+    var parent = {
+      key: null
+    };
+    var theirs = {
+      key: {
+        childKey: 'value1'
+      }
+    };
+    var mine = {
+      key: {
+        childKey: 'value2',
+      }
+    };
+    var expected = [
+      {
+        kind: 'C',
+        path: [ 'key', 'childKey'],
+        parent: parent.key,
+        theirs: theirs.key.childKey,
+        mine: mine.key.childKey
+      }
+    ];
+    assert.deepEqual(diff(parent, theirs, mine), expected);
+  });
 });
 
 // TODO These are probably useful tests https://github.com/falsecz/3-way-merge/blob/master/test/test.coffee


### PR DESCRIPTION
Error when an object existed but the parent/theirs/mine also existed but was defined as null with no properties.