### PR TITLE
JS Error fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,9 +94,9 @@ function recurse(parent, theirs, mine, path, options) {
  */
 function processKeyValuePair(key, value, parent, theirs, mine, path, options) {
   options = options || {};
-  var parentValue = (typeof parent !== 'undefined' && parent !== null && typeof parent[key] !== 'undefined') ? parent[key] : undefined;
-  var theirsValue = (typeof theirs !== 'undefined' && theirs !== null && typeof theirs[key] !== 'undefined') ? theirs[key] : undefined;
-  var mineValue = (typeof mine !== 'undefined' && mine !== null && typeof mine[key] !== 'undefined') ? mine[key] : undefined;
+  var parentValue = (!_.isUndefined(parent) && parent !== null && !_.isUndefined(parent[key])) ? parent[key] : undefined;
+  var theirsValue = (!_.isUndefined(theirs) && theirs !== null && !_.isUndefined(theirs[key])) ? theirs[key] : undefined;
+  var mineValue = (!_.isUndefined(mine) && mine !== null && !_.isUndefined(mine[key])) ? mine[key] : undefined;
   var results = [];
 
   // Only process keys that have no options, or have not been flagged as ignored
@@ -119,7 +119,13 @@ function processKeyValuePair(key, value, parent, theirs, mine, path, options) {
         path.push(key);
         for (var index in array) {
           path.push(index);
-          var differences = recurse(parentValue[index], theirsValue[index], mineValue[index], path, options[key] || {});
+          if (!_.isArray(parentValue) || _.isUndefined(parentValue)
+              || !_.isArray(theirsValue) || _.isUndefined(theirsValue)
+              || !_.isArray(mineValue) || _.isUndefined(mineValue)) {
+            var differences = compareValues(parentValue, theirsValue, mineValue, path, options[key] || {});
+          } else {
+            var differences = recurse(parentValue[index], theirsValue[index], mineValue[index], path, options[key] || {});
+          }
           if (differences) {
             results = results.concat(differences);
           }
@@ -130,7 +136,13 @@ function processKeyValuePair(key, value, parent, theirs, mine, path, options) {
     }
     else if (_.isObject(value)) {
       path.push(key);
-      var differences = recurse(parentValue, theirsValue, mineValue, path, options[key] || {});
+      if ((_.isUndefined(parentValue) || (!_.isObject(parentValue) && parentValue !== null))
+          || (_.isUndefined(theirsValue) || (!_.isObject(theirsValue) && theirsValue !== null))
+          || (_.isUndefined(mineValue) || (!_.isObject(mineValue) && mineValue !== null))) {
+        var differences = compareValues(parentValue, theirsValue, mineValue, path, options[key] || {});
+      } else {
+        var differences = recurse(parentValue, theirsValue, mineValue, path, options[key] || {});
+      }
       if (differences) {
         results = results.concat(differences);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3-way-diff",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "3-way diffing of JavaScript objects",
   "main": "index.js",
   "repository": "WennerMedia/3-way-diff",

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -250,6 +250,53 @@ describe('Array Diff', function() {
     ];
     assert.deepEqual(diff(parent, theirs, mine), expected);
   });
+
+  it('mine edits item to different type', function() {
+    var parent = {
+      key: [
+        {childKey1: 'value1'},
+        {childKey2: 'value2'}
+      ]
+    };
+    var theirs = {
+      key: [
+        {childKey1: 'value3'},
+        {childKey2: 'value2'}
+      ]
+    };
+    var mine = {
+      key: {
+        childKey1: 'value4',
+        childKey2: 'value2'
+      }
+    };
+    var expected = [
+      {
+        kind: 'N',
+        path: [ 'key', 'childKey1'],
+        mine: mine.key.childKey1
+      },
+      {
+        kind: 'N',
+        path: [ 'key', 'childKey2'],
+        mine: mine.key.childKey2
+      },
+      {
+        kind: 'D',
+        path: [ 'key', 0],
+        parent: parent.key[0],
+        theirs: theirs.key[0]
+      }
+      ,
+      {
+        kind: 'D',
+        path: [ 'key', 1],
+        parent: parent.key[1],
+        theirs: theirs.key[1]
+      }
+    ];
+    assert.deepEqual(diff(parent, theirs, mine), expected);
+  });
 });
 
 // TODO These are probably useful tests https://github.com/falsecz/3-way-merge/blob/master/test/test.coffee

--- a/test/literals.js
+++ b/test/literals.js
@@ -434,8 +434,8 @@ describe('Literals Diff', function() {
     var expected = [
       {
         kind: 'N',
-        path: [ 'key', 'childKey1', 'subChildKey'],
-        mine: mine.key.childKey1.subChildKey
+        path: [ 'key', 'childKey1'],
+        mine: mine.key.childKey1
       }
     ];
     assert.deepEqual(diff(parent, theirs, mine), expected);
@@ -466,7 +466,27 @@ describe('Literals Diff', function() {
     assert.deepEqual(diff(parent, theirs, mine, {keyIgnored: {ignoreKey: true}}), expected);
   });
 
-  it('mine add nested childKey where the parent key is null', function() {
+  it('mine add nested childKey where the parent is empty', function() {
+    var parent = {
+    };
+    var theirs = {
+    };
+    var mine = {
+      key: {
+        childKey: 'value',
+      }
+    };
+    var expected = [
+      {
+        kind: 'N',
+        path: [ 'key'],
+        mine: mine.key
+      }
+    ];
+    assert.deepEqual(diff(parent, theirs, mine), expected);
+  });
+
+  it('mine add nested childKey where the parent/theirs key are null', function() {
     var parent = {
       key: null
     };

--- a/test/literals.js
+++ b/test/literals.js
@@ -468,8 +468,10 @@ describe('Literals Diff', function() {
 
   it('mine add nested childKey where the parent is empty', function() {
     var parent = {
+
     };
     var theirs = {
+
     };
     var mine = {
       key: {
@@ -503,6 +505,52 @@ describe('Literals Diff', function() {
         kind: 'N',
         path: [ 'key', 'childKey'],
         mine: mine.key.childKey
+      }
+    ];
+    assert.deepEqual(diff(parent, theirs, mine), expected);
+  });
+
+  it('mine/theirs add nested childKey where the parent key is null', function() {
+    var parent = {
+      key: null
+    };
+    var theirs = {
+      key: {
+        childKey: 'value',
+      }
+    };
+    var mine = {
+      key: {
+        childKey: 'value',
+      }
+    };
+    var expected = [
+      // No differences
+    ];
+    assert.deepEqual(diff(parent, theirs, mine), expected);
+  });
+
+  it('mine/theirs add nested childKey with different values where the parent key is null', function() {
+    var parent = {
+      key: null
+    };
+    var theirs = {
+      key: {
+        childKey: 'value',
+      }
+    };
+    var mine = {
+      key: {
+        childKey: 'value1',
+      }
+    };
+    var expected = [
+      {
+        kind: 'C',
+        path: [ 'key', 'childKey'],
+        mine: mine.key.childKey,
+        theirs: theirs.key.childKey,
+        parent: parent.key
       }
     ];
     assert.deepEqual(diff(parent, theirs, mine), expected);


### PR DESCRIPTION
Fixed error when trying to reference key in parent/theirs/mine that doesn't exist.
When dealing with array/objects immediately compare values if there is a type mismatch or something is undefined.